### PR TITLE
Add number of recordings to menubar icon (like the entry in plugins menu)

### DIFF
--- a/src/Main.as
+++ b/src/Main.as
@@ -28,7 +28,7 @@ void RenderMenu()
 }
 
 void RenderMenuMain(){
-    if (g_replayRecord.m_inProgress && UI::MenuItem("\\$f00" + Icons::Circle + " \\$zReplay Recording in progress, click to stop")) {
+    if (g_replayRecord.m_inProgress && UI::MenuItem("\\$f00" + Icons::Circle + " \\$666("+g_replayRecord.m_totalRecorded+")" + " \\$zReplay Recording in progress, click to stop")) {
         g_replayRecord.m_inProgress = false;
         g_replayRecord.m_totalRecorded = 0;
     }


### PR DESCRIPTION
Thought this would be useful.
Otherwise you can only see the number of recordings in the plugins menu or if you have the main window visible.
I chose the color to match the color in the plugins menu.

![image](https://user-images.githubusercontent.com/1046448/170811315-9dfa42bf-d03a-4fab-ba81-35dd628abc33.png)

Spacing looks a little off after `(n)` even though there's a space there, so mb another space should be added.