### PR TITLE
Edit Update() to avoid null pointer access exception

### DIFF
--- a/src/ReplayRecorder.as
+++ b/src/ReplayRecorder.as
@@ -25,8 +25,10 @@ class ReplayRecord
     void Update()
     {
         @m_playground = cast<CSmArenaClient>(GetApp().CurrentPlayground);
-        @m_map = m_playground.Map;
         @m_playgroundScript = cast<CSmArenaRulesMode>(GetApp().PlaygroundScript);
+        if (m_playground !is null) {
+            @m_map = m_playground.Map;
+        }
 
         if (m_inProgress) {
             if (m_map !is null && m_playground !is null) {


### PR DESCRIPTION
I get this loading ReplayRecorder:

![image](https://user-images.githubusercontent.com/1046448/170849979-81b2b748-a22b-451b-8f82-e0357b0b19a1.png)

From what I can tell, this doesn't stop ReplayRecorder working, it's just a little annoying. This PR fixes it.