### PR TITLE
Some small UI and behaviour options

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -6,5 +6,4 @@ category = "Replay"
 version = "1.3"
 
 [script]
-imports = [ "Formatting.as" ]
 timeout = 0

--- a/src/Main.as
+++ b/src/Main.as
@@ -28,7 +28,34 @@ void RenderMenu()
 }
 
 void RenderMenuMain(){
-    if (g_replayRecord.m_inProgress && UI::MenuItem("\\$f00" + Icons::Circle + " \\$666("+g_replayRecord.m_totalRecorded+")" + " \\$zReplay Recording in progress")) {
+
+	string recColor, labelColor, totalColor;
+	if (blinkyOverlayLabel && (Time::get_Stamp() % 2 == 1)) {
+		recColor = "\\$800";
+		labelColor = "\\$666";
+		totalColor = "\\$333";
+	} else {
+		recColor = "\\$f00";
+		labelColor = "\\$z";
+		totalColor = "\\$666";
+	}
+
+
+	string overlayStr;
+	if (shortOverlayLabel) {
+		overlayStr = recColor + Icons::Circle + labelColor + " REC";
+	} else {
+		overlayStr = recColor + Icons::Circle + totalColor + " ("+g_replayRecord.m_totalRecorded+")" + labelColor + " Replay Recording in progress";
+	}
+	
+	auto pos_orig = UI::GetCursorPos();
+	auto textSize = Draw::MeasureString(overlayStr);
+	if (rightOverlayLabel) {
+		UI::SetCursorPos(vec2(UI::GetWindowSize().x - textSize.x - rightOverlayLabelOffset, pos_orig.y));
+	}
+
+	
+    if (g_replayRecord.m_inProgress && UI::MenuItem(overlayStr)) {
         g_replayRecord.m_inProgress = false;
         g_replayRecord.m_totalRecorded = 0;
     }
@@ -38,4 +65,7 @@ void RenderMenuMain(){
         UI::TextDisabled(Icons::InfoCircle + " Replays are saved to " + g_replayRecord.m_path);
         UI::EndTooltip();
     }
+	if (rightOverlayLabel) {
+		UI::SetCursorPos(pos_orig);
+	}
 }

--- a/src/ReplayRecorder.as
+++ b/src/ReplayRecorder.as
@@ -19,7 +19,7 @@ class ReplayRecord
         string replayPath = IO::FromUserGameFolder("Replays/ReplayRecorder");
         if (!IO::FolderExists(replayPath)) IO::CreateFolder(replayPath);
 
-        m_path = replayPath + "/" + Time::FormatString("%F_%H-%M-%S") + " - " + m_map.MapName;
+        m_path = replayPath + "/" + getFolderName();
     }
 
     void Update()
@@ -142,4 +142,17 @@ class ReplayRecord
 
         return result;
     }
+	
+	string getFolderName() {
+		switch (folderFormat) {
+			case folderMode::UID:
+				return m_map.MapInfo.MapUid;
+			case folderMode::UIDAndName:
+				return m_map.MapInfo.MapUid + " - " + m_map.MapName;
+			case folderMode::DateAndName: 
+			default:
+				return Time::FormatString("%F_%H-%M-%S") + " - " + m_map.MapName;
+		}
+		return "";
+	}
 }

--- a/src/Settings.as
+++ b/src/Settings.as
@@ -1,6 +1,11 @@
 [Setting category="Behavior" name="Automatically begin recording" description="If enabled, recording will automatically begin at the start of every map."]
 bool alwaysBeRecording = false;
 
+enum folderMode { DateAndName, UID, UIDAndName}
+[Setting category="Behavior" name="Folder format (requires reload)" description="How the folder structure will be set up for recorded replays."]
+folderMode folderFormat = folderMode::DateAndName;
+
+
 [Setting category="Display" name="Short label mode" description="A shorter (if less descriptive) recording in progress notification will be shown in the Overlay"]
 bool shortOverlayLabel = false;
 
@@ -10,5 +15,5 @@ bool blinkyOverlayLabel = false;
 [Setting category="Display" name="Right-hand label" description="Show the label on the right-hand side of the Overlay bar. You will need to manually adjust the offset to accomodate other plugins (like Clock)"]
 bool rightOverlayLabel = false;
 
-[Setting category="Display" name="Right-hand label offset" description="How far over to put the recording indicator. A value of 200 works well for the Clock plugin."]
+[Setting category="Display" drag name="Right-hand label offset" description="How far over to put the recording indicator. A value of 200 works well for the Clock plugin."]
 int rightOverlayLabelOffset = 0;

--- a/src/Settings.as
+++ b/src/Settings.as
@@ -1,0 +1,14 @@
+[Setting category="Behavior" name="Automatically begin recording" description="If enabled, recording will automatically begin at the start of every map."]
+bool alwaysBeRecording = false;
+
+[Setting category="Display" name="Short label mode" description="A shorter (if less descriptive) recording in progress notification will be shown in the Overlay"]
+bool shortOverlayLabel = false;
+
+[Setting category="Display" name="Blinking label" description="Blink the recording indicator, because it's aesthetic af."]
+bool blinkyOverlayLabel = false;
+
+[Setting category="Display" name="Right-hand label" description="Show the label on the right-hand side of the Overlay bar. You will need to manually adjust the offset to accomodate other plugins (like Clock)"]
+bool rightOverlayLabel = false;
+
+[Setting category="Display" name="Right-hand label offset" description="How far over to put the recording indicator. A value of 200 works well for the Clock plugin."]
+int rightOverlayLabelOffset = 0;


### PR DESCRIPTION
* Removes the deprecated `Formatting.as` call as this is built in to Openplanet now
* Allows changing the directory names used (adding UID-only and UID+Name options)
* Allows adjusting the "titlebar" recording indicator in a couple ways (shorter text, right-aligned, and/or blinky modes)

this also includes the settings option from #5 because i had a cherry-pick skill issue (it doesnt harm anything tho), sorry about that!